### PR TITLE
1. add --user to start activity - this is needed for new android devices...

### DIFF
--- a/src/adb/command/host-transport/startactivity.coffee
+++ b/src/adb/command/host-transport/startactivity.coffee
@@ -29,6 +29,5 @@ class StartActivityCommand extends Command
     if options.user
       args.push "--user #{options.user}"
 	startCmd = ((if options.isService then "startservice" else "start"))
-    this._send "shell:am " + startCmd + " #{args.join ' '}"
-
+	this._send "shell:am #{startCmd} #{args.join ' '}"
 module.exports = StartActivityCommand


### PR DESCRIPTION
... due to security issues, without the --user certain adb shell am commands fail

the value of --user can be simpley 0 (e.g am start com.myPackage.example --user 0)
2. add option to start a service and not just activities.
