### PR TITLE
Bump node-forge version to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "bluebird": "~2.9.24",
     "commander": "^2.3.0",
     "debug": "~2.6.3",
-    "node-forge": "^0.6.12",
+    "node-forge": "^0.7.1",
     "split": "~0.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This update is backwards compatible. Previous versions of `node-forge` used an AMD based module loader which made it impossible to use a bundler on `adbkit`. Later versions have switched to completely CommonJS. This fix allows me to bundle `adbkit` and run it in Electron.