### PR TITLE
Handle not empty disconnect message

### DIFF
--- a/src/adb/command/host/disconnect.coffee
+++ b/src/adb/command/host/disconnect.coffee
@@ -5,7 +5,8 @@ class DisconnectCommand extends Command
   # Possible replies:
   # "No such device 192.168.2.2:5555"
   # ""
-  RE_OK = /^$/
+  # disconnected host:port
+  RE_OK = /^disconnected (?:[0-9]{1,3}\.){3}[0-9]{1,3}\:?([0-9]{1,5})|(^$)/
 
   execute: (host, port) ->
     this._send "host:disconnect:#{host}:#{port}"

--- a/src/adb/command/host/disconnect.coffee
+++ b/src/adb/command/host/disconnect.coffee
@@ -6,7 +6,7 @@ class DisconnectCommand extends Command
   # "No such device 192.168.2.2:5555"
   # ""
   # disconnected host:port
-  RE_OK = /^disconnected (?:[0-9]{1,3}\.){3}[0-9]{1,3}\:?([0-9]{1,5})|(^$)/
+  RE_OK = /^disconnected |(^$)/
 
   execute: (host, port) ->
     this._send "host:disconnect:#{host}:#{port}"

--- a/src/adb/command/host/disconnect.coffee
+++ b/src/adb/command/host/disconnect.coffee
@@ -6,7 +6,7 @@ class DisconnectCommand extends Command
   # "No such device 192.168.2.2:5555"
   # ""
   # disconnected host:port
-  RE_OK = /^disconnected |(^$)/
+  RE_OK = /^disconnected |^$/
 
   execute: (host, port) ->
     this._send "host:disconnect:#{host}:#{port}"


### PR DESCRIPTION
Add a regexp what is handle blank string and  "disconnected host:port" formatted strings too.
#76 