### PR TITLE
Fix mocha command to work in Windows

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -63,7 +63,8 @@ module.exports = (grunt) ->
           '--colors'
           '--recursive'
         ],
-        cmd: './node_modules/.bin/mocha <%= exec.mocha.options.join(" ") %>'
+        cmd: 'node node_modules/mocha/bin/mocha
+              <%= exec.mocha.options.join(" ") %>'
     keycode:
       generate:
         dest: 'src/adb/keycode.coffee'


### PR DESCRIPTION
`npm install` fails on Windows since grunt-exec cannot handle paths like `./node_modules/.bin/...` on Windows. This patch makes it work on all three platforms.