### PR TITLE
Add module Setting to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "url": "https://openstf.io"
   },
   "main": "./index",
+  "module": "./lib/adb",
   "repository": {
     "type": "git",
     "url": "https://github.com/openstf/adbkit.git"


### PR DESCRIPTION
This is a workaround to get adbkit working with webpack and other, similar systems. It lets it know that imports should import `lib/adb.js` instead of `index.js`.

I will be sending a corresponding pull request for adbkit-monkey. adbkit-logcat doesn't need the workaround because it no longer uses CoffeeScript.