### PR TITLE
Fix for connection of adb server not starting the right server

### DIFF
--- a/src/adb/connection.coffee
+++ b/src/adb/connection.coffee
@@ -40,7 +40,7 @@ class Connection extends EventEmitter
 
   startServer: (callback) ->
     debug "Starting ADB server via '#{@options.bin} start-server'"
-    return this._exec ['start-server'], {}, callback
+    return this._exec ["-P #{@options.port}", "start-server"], {}, callback
 
   _exec: (args, options, callback) ->
     debug "CLI: #{@options.bin} #{args.join ' '}"


### PR DESCRIPTION
``` js
// if none of the server is started, this starts a adb server on port 5037
const client = adb.createClient({ port: 5038 });

// this fails to connect as it attempts to reach port 5038 and only 5037 is started.
await client.connect("host_ip");
```