### PR TITLE
fix sync.stat() failure for multibyte paths

### DIFF
--- a/src/adb/sync.coffee
+++ b/src/adb/sync.coffee
@@ -250,11 +250,12 @@ class Sync extends EventEmitter
 
   _sendCommandWithArg: (cmd, arg) ->
     debug "#{cmd} #{arg}"
-    payload = new Buffer cmd.length + 4 + arg.length
+    arglen = Buffer.byteLength arg, 'utf-8'
+    payload = new Buffer cmd.length + 4 + arglen
     pos = 0
     payload.write cmd, pos, cmd.length
     pos += cmd.length
-    payload.writeUInt32LE arg.length, pos
+    payload.writeUInt32LE arglen, pos
     pos += 4
     payload.write arg, pos
     @connection.write payload


### PR DESCRIPTION
### About
client.stat() fails for files with multi-byte filename like "あああ.txt" (japanese filename)
This will fix the problem.

### Root Cause:
In _sendCommandWithArg method, it uses arg.length for the binary payload size of arg. But if arg is multi-byte string, arg.length is wrong to be used for the purpose, because it is the count of characters and not the size of bytes.

### Solution
Use Buffer.byteLength(arg, 'utf-8') as the binary payload size of arg.
see: https://nodejs.org/api/buffer.html#buffer_class_method_buffer_bytelength_string_encoding

### Related
https://github.com/openstf/adbkit/issues/86 may be fixed with this fix.