### PR TITLE
Avoid crashing node due to post-setup connection errors

### DIFF
--- a/src/adb/client.coffee
+++ b/src/adb/client.coffee
@@ -63,16 +63,7 @@ class Client
     new TcpUsbServer this, serial, options
 
   connection: ->
-    resolver = Promise.defer()
-    conn = new Connection(@options)
-      .on 'error', errorListener = (err) ->
-        resolver.reject err
-      .on 'connect', connectListener = ->
-        resolver.resolve conn
-      .connect()
-    resolver.promise.finally ->
-      conn.removeListener 'error', errorListener
-      conn.removeListener 'connect', connectListener
+    new Connection(@options).connect()
 
   version: (callback) ->
     this.connection()

--- a/src/adb/sync.coffee
+++ b/src/adb/sync.coffee
@@ -147,10 +147,16 @@ class Sync extends EventEmitter
       stream.on 'error', errorListener = (err) ->
         resolver.reject err
 
-      resolver.promise.finally ->
+      @connection.on 'error', connErrorListener = (err) =>
+        stream.destroy(err)
+        @connection.end()
+        resolver.reject err
+
+      resolver.promise.finally =>
         stream.removeListener 'end', endListener
         stream.removeListener 'readable', readableListener
         stream.removeListener 'error', errorListener
+        @connection.removeListener 'error', connErrorListener
         writer.cancel()
 
     readReply = =>

--- a/test/mock/connection.coffee
+++ b/test/mock/connection.coffee
@@ -14,4 +14,6 @@ class MockConnection
     @socket.write.apply @socket, arguments
     return this
 
+  on: ->
+
 module.exports = MockConnection


### PR DESCRIPTION
Newly setup connections have an [error handler](https://github.com/openstf/adbkit/blob/master/src/adb/client.coffee#L68-L69) for errors during setup. Unfortunately, once initial connection is complete, this is [removed](https://github.com/openstf/adbkit/blob/master/src/adb/client.coffee#L74).

Subsequent code [listens to errors on the socket](https://github.com/openstf/adbkit/blob/7f1581016f1b1d4a8f4a45597f33ca09beed7332/src/adb/parser.coffee#L50), but not on the connection object, which re-emits the socket's errors. That means if any `'error'` events are fired on the ADB socket after initial setup, the entire node process crashes.

There's a few ways that this can manifest, but the easiest is any disconnection from ADB whilst an operation is in process.

On linux you can test this using [tcpkill](https://en.wikipedia.org/wiki/Tcpkill): `sudo tcpkill -i lo -9 dst port 5037`. This tries to aggressively inject RST packets into all active localhost:5037 connections. If you run this, and then try to do any non-trivial ADB process with adbkit, your node process will crash immediately. That's not great!

I'm hitting this in my own app ([HTTP Toolkit](https://httptoolkit.tech/android)), which uses adbkit under the hood. This PR solves it nicely, by:

* Stopping Connection from emitting errors unless the socket has no other error handlers
* Making errors that are emitted from Connection be re-emitted on the Client, so they can be handled there by downstream code with `client.on('error', ...)`.

I also noticed en route that the Sync command doesn't do any error checking on the ADB socket at all, that's now fixed (by the 2nd commit here).